### PR TITLE
Improve contextual conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ autoscan path/to/your/file.pdf
 
 # To process all PDFs in a directory:
 autoscan --directory path/to/your/pdf_directory
+
+# Use contextual conversion to maintain style between pages:
+autoscan --contextual-conversion path/to/your/file.pdf
 ```
+
+## Contextual Conversion
+
+Contextual conversion passes the Markdown from each page to the next page's conversion step. This helps the model
+maintain a consistent voice and formatting across pages.
+
+Enable this feature on the command line with `--contextual-conversion` or programmatically by passing
+`contextual_conversion=True` to the `autoscan` function. The returned `AutoScanOutput` includes the flag so you can
+verify whether it was used.
 
 
 ### Example
@@ -112,6 +124,7 @@ The output of the `autoscan` function includes:
 - `markdown`: The aggregated Markdown content.
 - `input_tokens`: Number of input tokens used.
 - `output_tokens`: Number of output tokens generated.
+- `contextual_conversion`: Whether contextual page processing was enabled.
 
 ## Examples
 

--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -92,12 +92,17 @@ async def autoscan(
         if not output_filename:
             raise MarkdownFileWriteError(f"Failed to write markdown file: {output_filename}")
 
-        logger.info(
-            f"Autoscan completed in {completion_time:.2f} seconds. "
-            f"Markdown file: {output_filename}. "
-            f"Tokens Usage - Input: {total_prompt_tokens}, Output: {total_completion_tokens}. "
-            f"Cost = ${total_cost:.2f}."
+        summary = "\n".join(
+            [
+                "AutoScan completed:",
+                f"  Output file      : {output_filename}",
+                f"  Completion time  : {completion_time:.2f} seconds",
+                f"  Tokens (in/out)  : {total_prompt_tokens}/{total_completion_tokens}",
+                f"  Cost             : ${total_cost:.2f}",
+                f"  Contextual mode  : {contextual_conversion}",
+            ]
         )
+        logger.info(summary)
         logger.info(
             f"To copy the markdown content to clipboard, run:\n"
             f"cat {output_filename} | pbcopy"
@@ -109,6 +114,7 @@ async def autoscan(
             markdown=markdown_content,
             input_tokens=total_prompt_tokens,
             output_tokens=total_completion_tokens,
+            contextual_conversion=contextual_conversion,
         )
     finally:
         # Clean up temp files if requested

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -8,18 +8,18 @@ from .autoscan import autoscan
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-async def _process_file(pdf_path: str) -> None:
+async def _process_file(pdf_path: str, contextual_conversion: bool) -> None:
     logging.info(f"Processing file: {pdf_path}")
-    await autoscan(pdf_path=pdf_path, contextual_conversion=False)
+    await autoscan(pdf_path=pdf_path, contextual_conversion=contextual_conversion)
 
-async def _run(pdf_path: str | None = None, directory: str | None = None) -> None:
+async def _run(pdf_path: str | None = None, directory: str | None = None, contextual_conversion: bool = False) -> None:
     if directory:
         logging.info(f"Processing all PDF files in directory: {directory}")
         for file_name in os.listdir(directory):
             if file_name.lower().endswith(".pdf"):
-                await _process_file(os.path.join(directory, file_name))
+                await _process_file(os.path.join(directory, file_name), contextual_conversion)
     elif pdf_path:
-        await _process_file(pdf_path)
+        await _process_file(pdf_path, contextual_conversion)
     else:
         logging.error("No valid input provided. Use --help for usage information.")
         sys.exit(1)
@@ -33,6 +33,11 @@ def main() -> None:
         "--directory",
         type=str,
         help="Path to a directory containing PDF files",
+    )
+    parser.add_argument(
+        "--contextual-conversion",
+        action="store_true",
+        help="Use previous page markdown when processing subsequent pages",
     )
 
     args = parser.parse_args()
@@ -50,7 +55,13 @@ def main() -> None:
         parser.print_help()
         return
 
-    asyncio.run(_run(pdf_path=args.pdf_path, directory=args.directory))
+    asyncio.run(
+        _run(
+            pdf_path=args.pdf_path,
+            directory=args.directory,
+            contextual_conversion=args.contextual_conversion,
+        )
+    )
 
 if __name__ == "__main__":
     main()

--- a/autoscan/types.py
+++ b/autoscan/types.py
@@ -7,6 +7,7 @@ class AutoScanOutput:
     markdown: str
     input_tokens: int
     output_tokens: int
+    contextual_conversion: bool
 
 
 @dataclass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import autoscan.cli as cli
+
+@pytest.mark.asyncio
+async def test_process_file_passes_contextual_flag():
+    called = {}
+
+    async def fake_autoscan(pdf_path, contextual_conversion=False):
+        called['flag'] = contextual_conversion
+
+    with patch('autoscan.cli.autoscan', new=fake_autoscan):
+        await cli._process_file('sample.pdf', True)
+
+    assert called.get('flag') is True


### PR DESCRIPTION
## Summary
- document contextual conversion
- show multi-line summary when autoscan completes
- fix newline endings in CLI and types

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
