### PR TITLE
Add debug flag for litellm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ autoscan --directory path/to/your/pdf_directory
 
 # Use contextual conversion to maintain style between pages:
 autoscan --contextual-conversion path/to/your/file.pdf
+
+# Enable litellm debug logging to see the raw prompts:
+autoscan --debug path/to/your/file.pdf
 ```
 
 ## Contextual Conversion
@@ -87,7 +90,7 @@ from autoscan.autoscan import autoscan
 
 async def main():
     pdf_path = "path/to/your/pdf_file.pdf"
-    output = await autoscan(pdf_path)
+    output = await autoscan(pdf_path, debug=True)
     print(output.markdown)
 
 asyncio.run(main())
@@ -112,9 +115,11 @@ async def autoscan(
     cleanup_temp: bool = True,
     concurrency: Optional[int] = 10,
     contextual_conversion: bool = False,
+    debug: bool = False,
 ) -> AutoScanOutput:
     ...
 ```
+Set `debug=True` to print the exact prompts being sent to the LLM.
 
 ## Output
 The output of the `autoscan` function includes:

--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -24,6 +24,7 @@ async def autoscan(
     cleanup_temp: bool = True,
     concurrency: Optional[int] = 10,
     contextual_conversion: bool = False,
+    debug: bool = False,
 ) -> AutoScanOutput:
     """
     Convert a PDF to markdown by:
@@ -39,6 +40,7 @@ async def autoscan(
     - `temp_dir` (str, optional): Directory for storing temporary images. If not specified, a temporary directory will be created and cleaned automatically after processing.
     - `cleanup_temp` (bool, optional): If `True`, cleans up temporary, intermediate files upon completion. Defaults to `True`.
     - `concurrency` (int, optional): Maximum number of concurrent model calls. Defaults to 10.
+    - `debug` (bool, optional): Enable litellm debug logging. Defaults to `False`.
 
     Returns:
         AutoScanOutput: Contains completion time, markdown file path, markdown content, and token usage.
@@ -70,7 +72,7 @@ async def autoscan(
         logger.info(f"Generated {len(images)} page images from PDF.")
 
         # Initialize the LLM
-        model = LlmModel(model_name=model_name)
+        model = LlmModel(model_name=model_name, debug=debug)
         logger.info(f"Initialized model: {model_name}")
 
         # Process images

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -8,18 +8,18 @@ from .autoscan import autoscan
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-async def _process_file(pdf_path: str, contextual_conversion: bool) -> None:
+async def _process_file(pdf_path: str, contextual_conversion: bool, debug: bool = False) -> None:
     logging.info(f"Processing file: {pdf_path}")
-    await autoscan(pdf_path=pdf_path, contextual_conversion=contextual_conversion)
+    await autoscan(pdf_path=pdf_path, contextual_conversion=contextual_conversion, debug=debug)
 
-async def _run(pdf_path: str | None = None, directory: str | None = None, contextual_conversion: bool = False) -> None:
+async def _run(pdf_path: str | None = None, directory: str | None = None, contextual_conversion: bool = False, debug: bool = False) -> None:
     if directory:
         logging.info(f"Processing all PDF files in directory: {directory}")
         for file_name in os.listdir(directory):
             if file_name.lower().endswith(".pdf"):
-                await _process_file(os.path.join(directory, file_name), contextual_conversion)
+                await _process_file(os.path.join(directory, file_name), contextual_conversion, debug)
     elif pdf_path:
-        await _process_file(pdf_path, contextual_conversion)
+        await _process_file(pdf_path, contextual_conversion, debug)
     else:
         logging.error("No valid input provided. Use --help for usage information.")
         sys.exit(1)
@@ -38,6 +38,11 @@ def main() -> None:
         "--contextual-conversion",
         action="store_true",
         help="Use previous page markdown when processing subsequent pages",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable litellm debug logging",
     )
 
     args = parser.parse_args()
@@ -60,6 +65,7 @@ def main() -> None:
             pdf_path=args.pdf_path,
             directory=args.directory,
             contextual_conversion=args.contextual_conversion,
+            debug=args.debug,
         )
     )
 

--- a/autoscan/model.py
+++ b/autoscan/model.py
@@ -1,6 +1,7 @@
 import os
 from typing import List, Dict, Any, Optional
 
+import litellm
 from litellm import acompletion
 
 from .image_processing import image_to_base64
@@ -15,14 +16,18 @@ class LlmModel:
     using an LLM. It can maintain formatting consistency with previously processed pages.
     """
 
-    def __init__(self, model_name: str = "openai/gpt-4o"):
+    def __init__(self, model_name: str = "openai/gpt-4o", debug: bool = False):
         """
         Initialize the LLM model interface.
 
         Args:
             model_name (str): The model name to use. Defaults to "openai/gpt-4o".
+            debug (bool): If True, enable litellm debug logging.
         """
         self._model_name = model_name
+        self._debug = debug
+        if debug:
+            litellm._turn_on_debug()
         self._system_prompt = DEFAULT_SYSTEM_PROMPT
         self._system_prompt_image_transcription = DEFAULT_SYSTEM_PROMPT_IMAGE_TRANSCRIPTION
         if not "OPENAI_API_KEY" in os.environ:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,12 @@ import autoscan.cli as cli
 async def test_process_file_passes_contextual_flag():
     called = {}
 
-    async def fake_autoscan(pdf_path, contextual_conversion=False):
+    async def fake_autoscan(pdf_path, contextual_conversion=False, debug=False):
         called['flag'] = contextual_conversion
+        called['debug'] = debug
 
     with patch('autoscan.cli.autoscan', new=fake_autoscan):
         await cli._process_file('sample.pdf', True)
 
     assert called.get('flag') is True
+    assert called.get('debug') is False


### PR DESCRIPTION
## Summary
- expose `--debug` flag in CLI
- allow enabling litellm debug logging via `autoscan` and `LlmModel`
- document debug usage
- update CLI tests for new parameter

## Testing
- `poetry run pytest -q` *(fails: Command not found)*