### PR TITLE
Introduce accuracy modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,22 +63,12 @@ autoscan path/to/your/file.pdf
 # To process all PDFs in a directory:
 autoscan --directory path/to/your/pdf_directory
 
-# Use contextual conversion to maintain style between pages:
-autoscan --contextual-conversion path/to/your/file.pdf
+# Choose accuracy level (low, medium, high):
+autoscan --accuracy high path/to/your/file.pdf
 
 # Enable litellm debug logging to see the raw prompts:
 autoscan --debug path/to/your/file.pdf
 ```
-
-## Contextual Conversion
-
-Contextual conversion passes the Markdown from each page to the next page's conversion step. This helps the model
-maintain a consistent voice and formatting across pages.
-
-Enable this feature on the command line with `--contextual-conversion` or programmatically by passing
-`contextual_conversion=True` to the `autoscan` function. The returned `AutoScanOutput` includes the flag so you can
-verify whether it was used.
-
 
 ### Example
 
@@ -107,14 +97,14 @@ You can configure the model and other parameters in the `autoscan` function:
 
 ```python
 async def autoscan(
-    pdf_path: str, 
+    pdf_path: str,
     model_name: str = "openai/gpt-4o",
+    accuracy: str = "medium",
     transcribe_images: Optional[bool] = True,
     output_dir: Optional[str] = None,
     temp_dir: Optional[str] = None,
     cleanup_temp: bool = True,
     concurrency: Optional[int] = 10,
-    contextual_conversion: bool = False,
     debug: bool = False,
 ) -> AutoScanOutput:
     ...
@@ -129,7 +119,7 @@ The output of the `autoscan` function includes:
 - `markdown`: The aggregated Markdown content.
 - `input_tokens`: Number of input tokens used.
 - `output_tokens`: Number of output tokens generated.
-- `contextual_conversion`: Whether contextual page processing was enabled.
+- `accuracy`: The accuracy level used for processing.
 
 ## Examples
 

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -8,18 +8,18 @@ from .autoscan import autoscan
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-async def _process_file(pdf_path: str, contextual_conversion: bool, debug: bool = False) -> None:
+async def _process_file(pdf_path: str, accuracy: str, debug: bool = False) -> None:
     logging.info(f"Processing file: {pdf_path}")
-    await autoscan(pdf_path=pdf_path, contextual_conversion=contextual_conversion, debug=debug)
+    await autoscan(pdf_path=pdf_path, accuracy=accuracy, debug=debug)
 
-async def _run(pdf_path: str | None = None, directory: str | None = None, contextual_conversion: bool = False, debug: bool = False) -> None:
+async def _run(pdf_path: str | None = None, directory: str | None = None, accuracy: str = "medium", debug: bool = False) -> None:
     if directory:
         logging.info(f"Processing all PDF files in directory: {directory}")
         for file_name in os.listdir(directory):
             if file_name.lower().endswith(".pdf"):
-                await _process_file(os.path.join(directory, file_name), contextual_conversion, debug)
+                await _process_file(os.path.join(directory, file_name), accuracy, debug)
     elif pdf_path:
-        await _process_file(pdf_path, contextual_conversion, debug)
+        await _process_file(pdf_path, accuracy, debug)
     else:
         logging.error("No valid input provided. Use --help for usage information.")
         sys.exit(1)
@@ -35,9 +35,11 @@ def main() -> None:
         help="Path to a directory containing PDF files",
     )
     parser.add_argument(
-        "--contextual-conversion",
-        action="store_true",
-        help="Use previous page markdown when processing subsequent pages",
+        "--accuracy",
+        type=str,
+        choices=["low", "medium", "high"],
+        default="medium",
+        help="Conversion accuracy level",
     )
     parser.add_argument(
         "--debug",
@@ -64,7 +66,7 @@ def main() -> None:
         _run(
             pdf_path=args.pdf_path,
             directory=args.directory,
-            contextual_conversion=args.contextual_conversion,
+            accuracy=args.accuracy,
             debug=args.debug,
         )
     )

--- a/autoscan/model.py
+++ b/autoscan/model.py
@@ -16,7 +16,7 @@ class LlmModel:
     using an LLM. It can maintain formatting consistency with previously processed pages.
     """
 
-    def __init__(self, model_name: str = "openai/gpt-4o", debug: bool = False):
+    def __init__(self, model_name: str = "openai/gpt-4o", debug: bool = False, accuracy: str = "medium"):
         """
         Initialize the LLM model interface.
 
@@ -26,10 +26,16 @@ class LlmModel:
         """
         self._model_name = model_name
         self._debug = debug
+        self._accuracy = accuracy
         self._system_prompt = DEFAULT_SYSTEM_PROMPT
         self._system_prompt_image_transcription = DEFAULT_SYSTEM_PROMPT_IMAGE_TRANSCRIPTION
         if not "OPENAI_API_KEY" in os.environ:
             raise ValueError("OPENAI_API_KEY environment variable is not set.")
+
+    @property
+    def accuracy(self) -> str:
+        """Return the accuracy level for this model."""
+        return self._accuracy
 
     @property
     def system_prompt(self) -> str:

--- a/autoscan/types.py
+++ b/autoscan/types.py
@@ -7,7 +7,7 @@ class AutoScanOutput:
     markdown: str
     input_tokens: int
     output_tokens: int
-    contextual_conversion: bool
+    accuracy: str
 
 
 @dataclass

--- a/tests/test_autoscan.py
+++ b/tests/test_autoscan.py
@@ -164,13 +164,14 @@ async def test_autoscan_with_custom_concurrency(tmp_path):
         result = await autoscan(pdf_path, temp_dir=str(temp_dir), output_dir=str(output_dir), concurrency=2)
         assert result is not None
         # Check that _process_images_async was called with concurrency=2
-        mock_process.assert_called_with(["image1.png", "image2.png", "image3.png"], 
-                                        mock_process.call_args[0][1],  # model (mocked)
-                                        True,  # transcribe_images default
-                                        concurrency=2)
+        mock_process.assert_called_with(["image1.png", "image2.png", "image3.png"],
+                                        mock_process.call_args[0][1],
+                                        True,
+                                        concurrency=2,
+                                        sequential=False)
 
 @pytest.mark.asyncio
-async def test_process_images_async_contextual():
+async def test_process_images_async_sequential():
     images = ["p1.png", "p2.png", "p3.png"]
     calls = []
 
@@ -184,7 +185,7 @@ async def test_process_images_async_contextual():
     model.image_to_markdown.side_effect = fake_image_to_markdown
 
     result = await autoscan_module._process_images_async(
-        images, model, True, concurrency=2, contextual_conversion=True
+        images, model, True, concurrency=2, sequential=True
     )
 
     assert calls == [None, "md_p1.png", "md_p2.png"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,15 +4,15 @@ from unittest.mock import AsyncMock, patch
 import autoscan.cli as cli
 
 @pytest.mark.asyncio
-async def test_process_file_passes_contextual_flag():
+async def test_process_file_passes_accuracy():
     called = {}
 
-    async def fake_autoscan(pdf_path, contextual_conversion=False, debug=False):
-        called['flag'] = contextual_conversion
+    async def fake_autoscan(pdf_path, accuracy="medium", debug=False):
+        called['accuracy'] = accuracy
         called['debug'] = debug
 
     with patch('autoscan.cli.autoscan', new=fake_autoscan):
-        await cli._process_file('sample.pdf', True)
+        await cli._process_file('sample.pdf', 'high')
 
-    assert called.get('flag') is True
+    assert called.get('accuracy') == 'high'
     assert called.get('debug') is False


### PR DESCRIPTION
## Summary
- add accuracy parameter and remove contextual flag
- update CLI and docs for low/medium/high modes
- process pages sequentially or in parallel based on accuracy
- adjust tests for new parameter
- remove redundant contextual argument when processing sequentially

## Testing
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest -q` *(fails: Command not found: pytest)*