### PR TITLE
Enable multiple LLM providers via LiteLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,27 @@ choco install poppler
 scoop install poppler
 ```
 
-### 3. Set your `OPENAI_API_KEY`
+### 3. Set your API key
 
-**macOS/Linux**:
+Depending on the model provider you choose, set the appropriate environment variable:
+
+- **OpenAI**: `OPENAI_API_KEY`
+- **Anthropic (Claude)**: `ANTHROPIC_API_KEY`
+- **Google Gemini**: `GOOGLE_API_KEY`
+
+**macOS/Linux example**:
 
 `export OPENAI_API_KEY=your_api_key`
 
-**Windows**:
+**Windows example**:
 
 `$env:OPENAI_API_KEY="your_api_key"`
 
-Replace `your_api_key` with your actual OpenAI API key.
+Replace `your_api_key` with your actual provider API key.
+AutoScan will check for the appropriate variable based on the
+provider prefix in the `--model` option. For example, if you use
+`--model anthropic/claude-3-sonnet-20240229`, ensure
+`ANTHROPIC_API_KEY` is defined.
 
 ## **Usage**
 
@@ -72,6 +82,9 @@ autoscan path/to/your/file.pdf
 
 # Choose accuracy level (low, medium, high):
 autoscan --accuracy high path/to/your/file.pdf
+
+# Specify a model (default is `openai/gpt-4o`):
+autoscan --model anthropic/claude-3-sonnet-20240229 path/to/your/file.pdf
 ```
 
 ### **Accuracy Levels**

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Depending on the model provider you choose, set the appropriate environment vari
 
 - **OpenAI**: `OPENAI_API_KEY`
 - **Anthropic (Claude)**: `ANTHROPIC_API_KEY`
-- **Google Gemini**: `GOOGLE_API_KEY`
+- **Google Gemini**: `GOOGLE_API_KEY` or `GEMINI_API_KEY` if using Google AI Studio (e.g.   `gemini/gemini-2.0-flash`)
 
 **macOS/Linux example**:
 
@@ -84,14 +84,14 @@ autoscan path/to/your/file.pdf
 autoscan --accuracy high path/to/your/file.pdf
 
 # Specify a model (default is `openai/gpt-4o`):
-autoscan --model anthropic/claude-3-sonnet-20240229 path/to/your/file.pdf
+autoscan --model gemini/gemini-2.0-flash path/to/your/file.pdf
 ```
 
-### **Accuracy Levels**
+### Accuracy Levels
 
 `low`, `medium`, and `high` are supported. Higher accuracy processes pages sequentially and performs an additional review step, which increases token usage (cost) and runtime.
 
-### **Programmatic Example**
+### Programmatic Example
 
 You can also invoke AutoScan in your Python code:
 
@@ -113,7 +113,7 @@ asyncio.run(main())
 2. **Process Images with LLM**: The images are processed by the LLM to generate Markdown.
 3. **Aggregate Markdown**: All Markdown output is combined into one file (on `accuracy==low` markdowns are combined together using a simple algorithm; on `accuracy==medium,high` an LLM is used to combine all outputs together)
 
-## **Configuration**
+## Configuration
 
 Configure models and other parameters using the `autoscan` function signature:
 

--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -179,7 +179,9 @@ async def _process_images_async(
                     previous_page_markdown=previous_page_markdown,
                 )
             except Exception as e:
-                raise LLMProcessingError(f"Error processing image '{image_path}': {e}. Aborting.")
+                raise LLMProcessingError(
+                    f"Error processing image '{image_path}': {e}"
+                ) from e
 
     if sequential:
         valid_results = []

--- a/autoscan/model.py
+++ b/autoscan/model.py
@@ -8,6 +8,7 @@ from .image_processing import image_to_base64
 from .types import ModelResult
 from .prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_SYSTEM_PROMPT_IMAGE_TRANSCRIPTION, FINAL_REVIEW_PROMPT
 from .config import LLMConfig
+from .utils.env import ensure_env_for_model
 import tiktoken
 
 class LlmModel:
@@ -29,8 +30,7 @@ class LlmModel:
         self._accuracy = accuracy
         self._system_prompt = DEFAULT_SYSTEM_PROMPT
         self._system_prompt_image_transcription = DEFAULT_SYSTEM_PROMPT_IMAGE_TRANSCRIPTION
-        if not "OPENAI_API_KEY" in os.environ:
-            raise ValueError("OPENAI_API_KEY environment variable is not set.")
+        ensure_env_for_model(model_name)
 
     @property
     def accuracy(self) -> str:

--- a/autoscan/model.py
+++ b/autoscan/model.py
@@ -10,6 +10,7 @@ from .prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_SYSTEM_PROMPT_IMAGE_TRANSCRI
 from .config import LLMConfig
 from .utils.env import ensure_env_for_model
 import tiktoken
+from .errors import LLMProcessingError
 
 class LlmModel:
     """
@@ -90,7 +91,7 @@ class LlmModel:
         if previous_page_markdown:
             user_content.append({
                 "type": "text",
-                "text": f"Here are the last 50 characters in Markdown format from the previous page to provide you context. "
+                "text": f"Here are the last few characters in Markdown format from the previous page to provide you context. "
                         f"The final output has no page breaks."
                         f"\n<!-- PAGE SEPARATOR -->\n{previous_page_markdown[-100:]}"
             })
@@ -142,8 +143,10 @@ class LlmModel:
                 completion_tokens=usage.completion_tokens,
                 cost=total_cost
             )
-        except Exception as err:
-            raise RuntimeError("Error: Image to markdown LLM call failed") from err
+        except Exception as err: 
+            raise LLMProcessingError(
+                f"Image to markdown LLM call failed: {err}"
+            ) from err
 
 
     async def postprocess_markdown(self, markdowns: List[str]) -> ModelResult:
@@ -196,7 +199,9 @@ class LlmModel:
             )
 
         except Exception as err:
-            raise RuntimeError("Error: Post-process LLM call failed.") from err
+            raise LLMProcessingError(
+                f"Post-process LLM call failed: {err}"
+            ) from err
   
     
     def _calculate_tokens(self, model_name: str, content: str) -> int:

--- a/autoscan/utils/env.py
+++ b/autoscan/utils/env.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import os
+
+MODEL_ENV_VARS = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "claude": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "gemini": "GOOGLE_API_KEY",
+}
+
+
+def get_env_var_for_model(model_name: str) -> str | None:
+    """Return the required environment variable for a provider if any."""
+    provider = model_name.split("/", 1)[0].lower()
+    return MODEL_ENV_VARS.get(provider)
+
+
+def ensure_env_for_model(model_name: str) -> None:
+    """Raise ValueError if the appropriate environment variable is missing."""
+    env_var = get_env_var_for_model(model_name)
+    if env_var and not os.environ.get(env_var):
+        raise ValueError(f"{env_var} environment variable is not set.")
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,17 +2,27 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 import autoscan.cli as cli
+from autoscan.utils.env import get_env_var_for_model
 
 @pytest.mark.asyncio
 async def test_process_file_passes_accuracy():
     called = {}
 
-    async def fake_autoscan(pdf_path, accuracy="medium", debug=False):
+    async def fake_autoscan(pdf_path, model_name="openai/gpt-4o", accuracy="medium", debug=False):
         called['accuracy'] = accuracy
         called['debug'] = debug
+        called['model'] = model_name
 
     with patch('autoscan.cli.autoscan', new=fake_autoscan):
-        await cli._process_file('sample.pdf', 'high')
+        await cli._process_file('sample.pdf', 'openai/gpt-4o', 'high')
 
     assert called.get('accuracy') == 'high'
     assert called.get('debug') is False
+    assert called.get('model') == 'openai/gpt-4o'
+
+
+def test_get_env_var_for_model():
+    assert get_env_var_for_model('openai/gpt-4o') == 'OPENAI_API_KEY'
+    assert get_env_var_for_model('anthropic/claude') == 'ANTHROPIC_API_KEY'
+    assert get_env_var_for_model('gemini/gemini-pro') == 'GOOGLE_API_KEY'
+    assert get_env_var_for_model('unknown/model') is None


### PR DESCRIPTION
## Summary
- support using Anthropic and Gemini models
- check environment variable based on chosen model
- expose `--model` CLI option
- document API key setup and `--model` usage
- add tests for CLI changes
- place `env` helpers in a utils module and simplify CLI checks

## Testing
- `poetry run pytest -q` *(fails: Command not found)*