### PR TITLE
Improve logging and reduce redundancy

### DIFF
--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -172,6 +172,7 @@ async def _process_images_async(
 
     async def process_single_image(image_path: str, previous_page_markdown: Optional[str] = None):
         async with context:
+            logger.debug(f"Processing image {image_path}")
             try:
                 return await model.image_to_markdown(
                     image_path,
@@ -179,6 +180,7 @@ async def _process_images_async(
                     previous_page_markdown=previous_page_markdown,
                 )
             except Exception as e:
+                logger.exception(f"Error processing image {image_path}: {e}")
                 raise LLMProcessingError(
                     f"Error processing image '{image_path}': {e}"
                 ) from e
@@ -199,6 +201,14 @@ async def _process_images_async(
     total_prompt_tokens = sum(r.prompt_tokens for r in valid_results)
     total_completion_tokens = sum(r.completion_tokens for r in valid_results)
     total_cost = sum(r.cost for r in valid_results)
+
+    logger.debug(
+        "Processed %s images: prompt_tokens=%s completion_tokens=%s cost=%s",
+        len(pdf_page_images),
+        total_prompt_tokens,
+        total_completion_tokens,
+        total_cost,
+    )
 
     return aggregated_markdown, total_prompt_tokens, total_completion_tokens, total_cost
           

--- a/autoscan/image_processing.py
+++ b/autoscan/image_processing.py
@@ -1,8 +1,6 @@
 import logging
-import os
-from typing import List, Optional, Tuple
+from typing import List, Optional
 import base64
-import io
 
 from pdf2image import convert_from_path
 
@@ -10,20 +8,23 @@ from .config import PDF2ImageConversionConfig
 
 def pdf_to_images(pdf_path: str, temp_folder: str) -> Optional[List[str]]:
     try:
+        logging.debug(f"Converting PDF {pdf_path} to images in {temp_folder}")
         image_paths = convert_from_path(
-            pdf_path, 
-            output_folder=temp_folder, 
-            paths_only=True, 
+            pdf_path,
+            output_folder=temp_folder,
+            paths_only=True,
             size=PDF2ImageConversionConfig.SIZE,
-            fmt=PDF2ImageConversionConfig.FORMAT, 
-            dpi=PDF2ImageConversionConfig.DPI, 
-            use_pdftocairo=PDF2ImageConversionConfig.USE_PDFTOCAIRO, 
+            fmt=PDF2ImageConversionConfig.FORMAT,
+            dpi=PDF2ImageConversionConfig.DPI,
+            use_pdftocairo=PDF2ImageConversionConfig.USE_PDFTOCAIRO,
             thread_count=PDF2ImageConversionConfig.NUM_THREADS)
+        logging.debug(f"Created {len(image_paths)} images")
         return image_paths
     except Exception as e:
         logging.error(f"Error converting PDF to images: {e}")
         return None
 
 def image_to_base64(image_path: str) -> str:
+    logging.debug(f"Encoding image {image_path} to base64")
     with open(image_path, "rb") as image_file:
         return base64.b64encode(image_file.read()).decode("utf-8")


### PR DESCRIPTION
## Summary
- add debug logging to `get_or_download_file` and `write_text_to_file`
- add debug logging to PDF conversion helpers
- improve error logging in `autoscan` main helpers
- refactor `LlmModel` with reusable `_strip_code_fences` and logging

## Testing
- `pytest -q` *(fails: command not found)*