### PR TITLE
Ensure images are always transcribed and add optional context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ When perfect accuracy is not essential, faster and cheaper alternatives (e.g. [P
 - **Image transcription** so visuals are described in text rather than embedded.
 - **Handwriting OCR** when handwritten notes are present.
 - **Multi-language** support.
+- **Optional user instructions** passed directly to the LLM for custom behavior.
 - **Works with any LLM** via [LiteLLM](https://github.com/BerriAI/litellm).
 
 ![Example 1](assets/pdf_to_md_eg_1.png)
@@ -85,6 +86,9 @@ autoscan --accuracy high path/to/your/file.pdf
 
 # Specify a model (default is `openai/gpt-4o`):
 autoscan --model gemini/gemini-2.0-flash path/to/your/file.pdf
+
+# Provide additional instructions for the LLM:
+autoscan --instructions "This is an invoice; use GitHub tables" path/to/your/file.pdf
 ```
 
 ### Accuracy Levels
@@ -122,7 +126,7 @@ async def autoscan(
     pdf_path: str,
     model_name: str = "openai/gpt-4o",
     accuracy: str = "medium",
-    transcribe_images: Optional[bool] = True,
+    user_instructions: Optional[str] = None,
     temp_dir: Optional[str] = None,
     cleanup_temp: bool = True,
     concurrency: Optional[int] = 10,

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -9,13 +9,31 @@ from .utils.env import get_env_var_for_model
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-async def _process_file(pdf_path: str, model: str, accuracy: str, debug: bool = False) -> None:
+async def _process_file(
+    pdf_path: str,
+    model: str,
+    accuracy: str,
+    instructions: str | None = None,
+    debug: bool = False,
+) -> None:
     logging.info(f"Processing file: {pdf_path}")
-    await autoscan(pdf_path=pdf_path, model_name=model, accuracy=accuracy, debug=debug)
+    await autoscan(
+        pdf_path=pdf_path,
+        model_name=model,
+        accuracy=accuracy,
+        user_instructions=instructions,
+        debug=debug,
+    )
 
-async def _run(pdf_path: str | None = None, model: str = "openai/gpt-4o", accuracy: str = "medium", debug: bool = False) -> None:
+async def _run(
+    pdf_path: str | None = None,
+    model: str = "openai/gpt-4o",
+    accuracy: str = "medium",
+    instructions: str | None = None,
+    debug: bool = False,
+) -> None:
     if pdf_path:
-        await _process_file(pdf_path, model, accuracy, debug)
+        await _process_file(pdf_path, model, accuracy, instructions, debug)
     else:
         logging.error("No valid input provided. Use --help for usage information.")
         sys.exit(1)
@@ -38,6 +56,11 @@ def main() -> None:
         type=str,
         default="openai/gpt-4o",
         help="Model name to use with LiteLLM",
+    )
+    parser.add_argument(
+        "--instructions",
+        type=str,
+        help="Optional instructions passed to the LLM",
     )
     parser.add_argument(
         "--debug",
@@ -65,6 +88,7 @@ def main() -> None:
             pdf_path=args.pdf_path,
             model=args.model,
             accuracy=args.accuracy,
+            instructions=args.instructions,
             debug=args.debug,
         )
     )

--- a/autoscan/prompts.py
+++ b/autoscan/prompts.py
@@ -1,12 +1,5 @@
-DEFAULT_SYSTEM_PROMPT = (
-    "Convert the following PDF page to Markdown. "
-    "Include all text, tables, lists, and images. "
-    "Use proper Markdown syntax for lists and tables, and embed images with meaningful alt text. "
-    "Return plain Markdown only - do not wrap the output in code fences or add explanations."
-)
-
-DEFAULT_SYSTEM_PROMPT_IMAGE_TRANSCRIPTION = """
-Your task is to accurately convert the content of a single PDF page into properly structured Markdown format.  The conversion must include all textual elements, as well as tables and image descriptions. Do not provide any explanation or commentary outside of the Markdown output. 
+DEFAULT_SYSTEM_PROMPT = """
+Your task is to accurately convert the content of a single PDF page into properly structured Markdown format.  The conversion must include all textual elements, as well as tables and image descriptions. Do not provide any explanation or commentary outside of the Markdown output.
 
 ## Instructions
 

--- a/tests/test_autoscan.py
+++ b/tests/test_autoscan.py
@@ -164,18 +164,20 @@ async def test_autoscan_with_custom_concurrency(tmp_path):
         result = await autoscan(pdf_path, temp_dir=str(temp_dir), output_dir=str(output_dir), concurrency=2)
         assert result is not None
         # Check that _process_images_async was called with concurrency=2
-        mock_process.assert_called_with(["image1.png", "image2.png", "image3.png"],
-                                        mock_process.call_args[0][1],
-                                        True,
-                                        concurrency=2,
-                                        sequential=False)
+        mock_process.assert_called_with(
+            ["image1.png", "image2.png", "image3.png"],
+            mock_process.call_args[0][1],
+            concurrency=2,
+            sequential=False,
+            user_instructions=None,
+        )
 
 @pytest.mark.asyncio
 async def test_process_images_async_sequential():
     images = ["p1.png", "p2.png", "p3.png"]
     calls = []
 
-    async def fake_image_to_markdown(image_path, transcribe_images=False, previous_page_markdown=None):
+    async def fake_image_to_markdown(image_path, previous_page_markdown=None, user_instructions=None):
         calls.append(previous_page_markdown)
         return ModelResult(
             content=f"md_{image_path}", prompt_tokens=1, completion_tokens=1, cost=0.0
@@ -185,7 +187,7 @@ async def test_process_images_async_sequential():
     model.image_to_markdown.side_effect = fake_image_to_markdown
 
     result = await autoscan_module._process_images_async(
-        images, model, True, concurrency=2, sequential=True
+        images, model, concurrency=2, sequential=True, user_instructions=None
     )
 
     assert calls == [None, "md_p1.png", "md_p2.png"]


### PR DESCRIPTION
## Summary
- remove optional `transcribe_images` mode and always describe images
- allow passing custom instructions to the LLM via API/CLI
- update documentation for new `user_instructions` parameter and CLI flag
- update tests for new behaviour

## Testing
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest -q` *(fails: Command not found: pytest)*