### PR TITLE
Remove debug flag and add log-level

### DIFF
--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -23,7 +23,6 @@ async def autoscan(
     temp_dir: Optional[str] = None,
     cleanup_temp: bool = True,
     concurrency: Optional[int] = 10,
-    debug: bool = False,
 ) -> AutoScanOutput:
     """
     Convert a PDF to markdown by:
@@ -40,7 +39,6 @@ async def autoscan(
     - `temp_dir` (str, optional): Directory for storing temporary images. If not specified, a temporary directory will be created and cleaned automatically after processing.
     - `cleanup_temp` (bool, optional): If `True`, cleans up temporary, intermediate files upon completion. Defaults to `True`.
     - `concurrency` (int, optional): Maximum number of concurrent model calls. Defaults to 10.
-    - `debug` (bool, optional): Enable litellm debug logging. Defaults to `False`.
 
     Returns:
         AutoScanOutput: Contains completion time, markdown file path, markdown content, and token usage.
@@ -72,7 +70,7 @@ async def autoscan(
         logger.info(f"Generated {len(images)} page images from PDF.")
 
         # Initialize the LLM
-        model = LlmModel(model_name=model_name, debug=debug, accuracy=accuracy)
+        model = LlmModel(model_name=model_name, accuracy=accuracy)
         logger.info(f"Initialized model: {model_name}")
 
         # Process images

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -14,7 +14,6 @@ async def _process_file(
     model: str,
     accuracy: str,
     instructions: str | None = None,
-    debug: bool = False,
 ) -> None:
     logging.info(f"Processing file: {pdf_path}")
     await autoscan(
@@ -22,7 +21,6 @@ async def _process_file(
         model_name=model,
         accuracy=accuracy,
         user_instructions=instructions,
-        debug=debug,
     )
 
 async def _run(
@@ -30,10 +28,9 @@ async def _run(
     model: str = "openai/gpt-4o",
     accuracy: str = "medium",
     instructions: str | None = None,
-    debug: bool = False,
 ) -> None:
     if pdf_path:
-        await _process_file(pdf_path, model, accuracy, instructions, debug)
+        await _process_file(pdf_path, model, accuracy, instructions)
     else:
         logging.error("No valid input provided. Use --help for usage information.")
         sys.exit(1)
@@ -63,9 +60,11 @@ def main() -> None:
         help="Optional instructions passed to the LLM",
     )
     parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Enable litellm debug logging",
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Set the logging level",
     )
 
     args = parser.parse_args()
@@ -83,13 +82,14 @@ def main() -> None:
         parser.print_help()
         return
 
+    logging.getLogger().setLevel(getattr(logging, args.log_level))
+
     asyncio.run(
         _run(
             pdf_path=args.pdf_path,
             model=args.model,
             accuracy=args.accuracy,
             instructions=args.instructions,
-            debug=args.debug,
         )
     )
 

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -82,8 +82,9 @@ def main() -> None:
         parser.print_help()
         return
 
-    logging.getLogger().setLevel(getattr(logging, args.log_level))
+    args = parser.parse_args()
 
+    logging.basicConfig(level=getattr(logging, args.log_level), format="%(asctime)s - %(levelname)s - %(message)s")
     asyncio.run(
         _run(
             pdf_path=args.pdf_path,

--- a/autoscan/model.py
+++ b/autoscan/model.py
@@ -23,9 +23,8 @@ class LlmModel:
     """
 
     def __init__(
-        self, 
-        model_name: str = "openai/gpt-4o", 
-        debug: bool = False, 
+        self,
+        model_name: str = "openai/gpt-4o",
         accuracy: str = "medium"
     ):
         """
@@ -33,11 +32,9 @@ class LlmModel:
 
         Args:
             model_name (str): The model name to use. Defaults to "openai/gpt-4o".
-            debug (bool): If True, log LLM prompts and responses at DEBUG level.
             accuracy (str): An accuracy level descriptor. Defaults to "medium".
         """
         self._model_name = model_name
-        self._debug = debug
         self._accuracy = accuracy
         self._system_prompt = DEFAULT_SYSTEM_PROMPT
         ensure_env_for_model(model_name)
@@ -87,12 +84,12 @@ class LlmModel:
 
     def _maybe_log_debug_messages(self, messages: List[Dict[str, Any]]) -> None:
         """
-        Log messages at DEBUG level if self._debug is True, otherwise do nothing.
+        Log messages at DEBUG level if the logger is configured accordingly.
 
         Args:
             messages (List[Dict[str, Any]]): The messages to log.
         """
-        if not self._debug:
+        if not logger.isEnabledFor(logging.DEBUG):
             return
 
         for msg in messages:
@@ -223,7 +220,7 @@ class LlmModel:
             {"role": "user", "content": user_content}
         ]
 
-        # Log messages if debug is enabled
+        # Log messages if DEBUG level is enabled
         self._maybe_log_debug_messages(messages)
 
         try:
@@ -239,7 +236,7 @@ class LlmModel:
             usage = response.usage
             total_cost = self._calculate_cost(usage)
 
-            # Log the assistant's response if debug is enabled
+            # Log the assistant's response if DEBUG level is enabled
             self._maybe_log_debug_messages([
                 {"role": "assistant", "content": content}
             ])
@@ -289,7 +286,7 @@ class LlmModel:
             {"role": "user", "content": user_content}
         ]
 
-        # Log messages if debug is enabled
+        # Log messages if DEBUG level is enabled
         self._maybe_log_debug_messages(messages)
 
         try:
@@ -301,7 +298,7 @@ class LlmModel:
             raw_content = response.choices[0].message.content.strip()
             content = self._strip_code_fences(raw_content)
 
-            # Log the final content if debug is enabled
+            # Log the final content if DEBUG level is enabled
             self._maybe_log_debug_messages([
                 {"role": "assistant", "content": content}
             ])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,16 +8,14 @@ from autoscan.utils.env import get_env_var_for_model
 async def test_process_file_passes_accuracy():
     called = {}
 
-    async def fake_autoscan(pdf_path, model_name="openai/gpt-4o", accuracy="medium", debug=False):
+    async def fake_autoscan(pdf_path, model_name="openai/gpt-4o", accuracy="medium", user_instructions=None):
         called['accuracy'] = accuracy
-        called['debug'] = debug
         called['model'] = model_name
 
     with patch('autoscan.cli.autoscan', new=fake_autoscan):
         await cli._process_file('sample.pdf', 'openai/gpt-4o', 'high')
 
     assert called.get('accuracy') == 'high'
-    assert called.get('debug') is False
     assert called.get('model') == 'openai/gpt-4o'
 
 


### PR DESCRIPTION
## Summary
- add log level option to CLI and set root logger level from it
- remove `--debug` flag usage
- rely on logging level for prompt debug output
- update tests for new CLI behavior

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*