### PR TITLE
Update to join pages directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ autoscan --instructions "This is an invoice; use GitHub tables" path/to/your/fil
 
 ### Accuracy Levels
 
-`low`, `medium`, and `high` are supported. Higher accuracy processes pages sequentially and performs an additional review step, which increases token usage (cost) and runtime.
+`low`, `medium`, and `high` are supported. Higher accuracy processes pages sequentially to provide context, which increases token usage (cost) and runtime.
 
 ### Programmatic Example
 
@@ -115,7 +115,7 @@ asyncio.run(main())
 
 1. **Convert PDF to Images**: Each page of the PDF is converted into an image.
 2. **Process Images with LLM**: The images are processed by the LLM to generate Markdown.
-3. **Aggregate Markdown**: All Markdown output is combined into one file (on `accuracy==low` markdowns are combined together using a simple algorithm; on `accuracy==medium,high` an LLM is used to combine all outputs together)
+3. **Aggregate Markdown**: All Markdown output is combined into one file using a simple algorithm.
 
 ## Configuration
 

--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -78,7 +78,6 @@ async def autoscan(
             raise ValueError("accuracy must be one of 'low', 'medium', or 'high'")
 
         sequential = accuracy == "high"
-        do_postprocess = accuracy in {"medium", "high"}
 
         (
             aggregated_markdown,
@@ -93,10 +92,7 @@ async def autoscan(
             user_instructions=user_instructions,
         )
 
-        if do_postprocess:
-            markdown_content = await _postprocess_markdown(aggregated_markdown, model)
-        else:
-            markdown_content = "\n".join(aggregated_markdown).replace("---PAGE BREAK---", "")
+        markdown_content = "\n".join(aggregated_markdown).replace("---PAGE BREAK---", "")
 
         end_time = datetime.now()
         completion_time = (end_time - start_time).total_seconds()
@@ -136,20 +132,6 @@ async def autoscan(
         if cleanup_temp and images:
             await asyncio.to_thread(_cleanup_temp_files, images)
 
-async def _postprocess_markdown(markdown: List[str], model: LlmModel) -> str:
-    """
-    Post-process the markdown content using the given LLM model.
-
-    Args:
-        markdown: List of markdown strings to process.
-        model: LlmModel instance for review.
-
-    Returns:
-        The aggregated markdown content.
-    """
-    result = await model.postprocess_markdown(markdown)
-
-    return result.content
 
 async def _process_images_async(
     pdf_page_images: List[str],

--- a/autoscan/prompts.py
+++ b/autoscan/prompts.py
@@ -34,21 +34,3 @@ You are given an image of a PDF page (called main image). Your task is to conver
 
 **Your response must follow these rules and contain only the converted Markdown content.**
     """
-
-FINAL_REVIEW_PROMPT = """
-You have been provided multiple Markdown files, each representing a single PDF page that was independently converted by an LLM. These individual pages may contain inconsistencies in headings, paragraph breaks, and formatting. Your goal is to merge them into one coherent, well-structured Markdown document. Follow the instructions below:
-
-**Instructions:**
-1. **Combine and Clean:** Consolidate all pages into a single document. Remove any `---PAGE BREAK---` or similar markers.
-2. **Consistent Headings and Structure:** Ensure headings follow a logical hierarchy throughout. Fix any inconsistent heading levels.
-3. **Paragraph Flow:** Merge paragraphs when appropriate to create smooth transitions. Remove unnecessary line breaks.
-4. **Standardize Formatting:** 
-   - Ensure lists, tables, footnotes, image descriptions, and code blocks have consistent formatting.
-   - If the text contains repeated headers or footers, remove duplicates that do not add new meaning.
-5. **Maintain Content:** Retain all original information. Do not remove any meaningful text. Eliminate redundancies or obvious errors without altering the text's meaning.
-6. **Math and LaTeX:** Replace any `\(...\)` LaTeX formatting with `$$...$$` for proper KaTeX rendering.
-7. **Output Requirements:** 
-   - Return only the revised, merged Markdown.
-   - Enclose the final output in a fenced code block (triple backticks).
-   - Do not include any commentary or explanation of your changes.
-"""


### PR DESCRIPTION
## Summary
- document that higher accuracy only processes pages sequentially
- remove final review post-processing step
- keep 100 tokens of previous page for context

## Testing
- `python3 -m py_compile autoscan/*.py tests/*.py`
- `pytest -q` *(fails: command not found)*