### PR TITLE
Update high mode context and remove review LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ autoscan --instructions "This is an invoice; use GitHub tables" path/to/your/fil
 
 ### Accuracy Levels
 
-`low`, `medium`, and `high` are supported. Higher accuracy processes pages sequentially and performs an additional review step, which increases token usage (cost) and runtime.
+`low`, `medium`, and `high` are supported. Higher accuracy processes pages sequentially. When using `high`, the entire previous page is sent back to the model for context, which increases token usage (cost) and runtime.
 
 ### Programmatic Example
 
@@ -115,7 +115,7 @@ asyncio.run(main())
 
 1. **Convert PDF to Images**: Each page of the PDF is converted into an image.
 2. **Process Images with LLM**: The images are processed by the LLM to generate Markdown.
-3. **Aggregate Markdown**: All Markdown output is combined into one file (on `accuracy==low` markdowns are combined together using a simple algorithm; on `accuracy==medium,high` an LLM is used to combine all outputs together)
+3. **Aggregate Markdown**: All Markdown output is combined into one file using a simple algorithm.
 
 ## Configuration
 

--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -78,7 +78,6 @@ async def autoscan(
             raise ValueError("accuracy must be one of 'low', 'medium', or 'high'")
 
         sequential = accuracy == "high"
-        do_postprocess = accuracy in {"medium", "high"}
 
         (
             aggregated_markdown,
@@ -93,10 +92,7 @@ async def autoscan(
             user_instructions=user_instructions,
         )
 
-        if do_postprocess:
-            markdown_content = await _postprocess_markdown(aggregated_markdown, model)
-        else:
-            markdown_content = "\n".join(aggregated_markdown).replace("---PAGE BREAK---", "")
+        markdown_content = "\n".join(aggregated_markdown).replace("---PAGE BREAK---", "")
 
         end_time = datetime.now()
         completion_time = (end_time - start_time).total_seconds()
@@ -136,20 +132,6 @@ async def autoscan(
         if cleanup_temp and images:
             await asyncio.to_thread(_cleanup_temp_files, images)
 
-async def _postprocess_markdown(markdown: List[str], model: LlmModel) -> str:
-    """
-    Post-process the markdown content using the given LLM model.
-
-    Args:
-        markdown: List of markdown strings to process.
-        model: LlmModel instance for review.
-
-    Returns:
-        The aggregated markdown content.
-    """
-    result = await model.postprocess_markdown(markdown)
-
-    return result.content
 
 async def _process_images_async(
     pdf_page_images: List[str],

--- a/autoscan/autoscan.py
+++ b/autoscan/autoscan.py
@@ -92,7 +92,7 @@ async def autoscan(
             user_instructions=user_instructions,
         )
 
-        markdown_content = "\n".join(aggregated_markdown).replace("---PAGE BREAK---", "")
+        markdown_content = "\n\n".join(aggregated_markdown).replace("---PAGE BREAK---", "")
 
         end_time = datetime.now()
         completion_time = (end_time - start_time).total_seconds()

--- a/autoscan/model.py
+++ b/autoscan/model.py
@@ -128,8 +128,7 @@ class LlmModel:
 
     def _calculate_cost(self, usage) -> float:
         """
-        Safely calculate the cost for the given usage object. 
-        If cost calculation fails, return 0.0 and log an error.
+        Safely calculate the cost for the given usage object. If cost calculation fails, return 0.0 and log an error.
 
         Args:
             usage (Any): The usage object returned by the LLM API.
@@ -189,8 +188,7 @@ class LlmModel:
 
         Args:
             image_path (str): Path to the image file of the PDF page.
-            previous_page_markdown (Optional[str]): Markdown of the previous page 
-                                                    (for formatting context).
+            previous_page_markdown (Optional[str]): Markdown of the previous page (for formatting context).
             user_instructions (Optional[str]): Additional instructions from the user.
 
         Returns:
@@ -227,14 +225,14 @@ class LlmModel:
             if self._accuracy == "high":
                 context_md = previous_page_markdown
                 intro = (
-                    "Here is the previous page in Markdown format to provide context.\n"
-                    "Use the same style; the final output has no page breaks."
+                    "Here is the converted markdown of the previous page to provide you context and to help you maintain consistency in the output.\n"
+                    "Do not change or alter this content; ensure that the final output has no page breaks."
                 )
             else:
                 context_md = self._get_last_n_tokens(previous_page_markdown, 100)
                 intro = (
-                    "Here are the last 100 tokens from the previous page in Markdown format to provide context.\n"
-                    "Use the same style; the final output has no page breaks."
+                    "Here is the converted markdown of the last few words from the previous page to provide you context and to help you maintain consistency in the output.\n"
+                    "Do not change or alter this content; ensure that the final output has no page breaks."
                 )
 
             user_content.append({

--- a/autoscan/prompts.py
+++ b/autoscan/prompts.py
@@ -34,21 +34,3 @@ You are given an image of a PDF page (called main image). Your task is to conver
 
 **Your response must follow these rules and contain only the converted Markdown content.**
     """
-
-FINAL_REVIEW_PROMPT = """
-You have been provided multiple Markdown files, each representing a single PDF page that was independently converted by an LLM. These individual pages may contain inconsistencies in headings, paragraph breaks, and formatting. Your goal is to merge them into one coherent, well-structured Markdown document. Follow the instructions below:
-
-**Instructions:**
-1. **Combine and Clean:** Consolidate all pages into a single document. Remove any `---PAGE BREAK---` or similar markers.
-2. **Consistent Headings and Structure:** Ensure headings follow a logical hierarchy throughout. Fix any inconsistent heading levels.
-3. **Paragraph Flow:** Merge paragraphs when appropriate to create smooth transitions. Remove unnecessary line breaks.
-4. **Standardize Formatting:** 
-   - Ensure lists, tables, footnotes, image descriptions, and code blocks have consistent formatting.
-   - If the text contains repeated headers or footers, remove duplicates that do not add new meaning.
-5. **Maintain Content:** Retain all original information. Do not remove any meaningful text. Eliminate redundancies or obvious errors without altering the text's meaning.
-6. **Math and LaTeX:** Replace any `\(...\)` LaTeX formatting with `$$...$$` for proper KaTeX rendering.
-7. **Output Requirements:** 
-   - Return only the revised, merged Markdown.
-   - Enclose the final output in a fenced code block (triple backticks).
-   - Do not include any commentary or explanation of your changes.
-"""

--- a/autoscan/prompts.py
+++ b/autoscan/prompts.py
@@ -5,8 +5,8 @@ You are given an image of a PDF page (called main image). Your task is to conver
 
 1. **General Guidelines:**
     - Convert **all** meaningful textual content from the main image into Markdown. This includes: 
-        - Headings, paragraphs, lists, footnotes, side notes, captions, and any other text blocks.
-        - **Do not** include page numbers or repetitive headers/footers with no meaningful content. 
+        - Headings, paragraphs, lists, footnotes, side notes, captions, and any other text blocks. You'll need to infer these from the layout and make best possible formatting decisions. E.g. if you notice a list implicitly e.g. the items are indented, or if you see a heading, or a caption, etc. Use appropriate Markdown syntax for each type of content:
+        - **Do not** include page numbers or repetitive headers/footers with no meaningful content or have already been captured.
     - If underlining or other emphasis can't be directly represented, default to italics  (`*...*` or `_..._`).
     - Retain URLs, but convert them to Markdown links: `[link text](url)`
     - Use `>` for blockquotes and sidebars.

--- a/tests/test_autoscan.py
+++ b/tests/test_autoscan.py
@@ -19,8 +19,7 @@ async def test_autoscan_successful(tmp_path):
          patch("autoscan.autoscan.pdf_to_images", new=MagicMock(return_value=["image1.png", "image2.png"])) as mock_pdf_to_images, \
          patch("autoscan.autoscan._process_images_async", new=AsyncMock(return_value=(["Markdown Page 1", "Markdown Page 2"], 100, 200, 0.5))) as mock_process, \
          patch("autoscan.autoscan.write_text_to_file", new=AsyncMock(return_value=str(output_dir / "sample.md"))) as mock_write, \
-         patch("autoscan.autoscan.LlmModel") as MockModel, \
-         patch("autoscan.autoscan._postprocess_markdown", return_value="Markdown Page 1\nMarkdown Page 2"), \
+        patch("autoscan.autoscan.LlmModel") as MockModel, \
          patch("os.makedirs") as mock_makedirs:
 
         # Mock the LlmModel
@@ -66,7 +65,6 @@ async def test_autoscan_no_images_generated(tmp_path):
     # Mock dependencies
     with patch("autoscan.autoscan.get_or_download_file", new=AsyncMock(return_value=str(temp_dir / "sample.pdf"))), \
          patch("autoscan.autoscan.pdf_to_images", new=MagicMock(return_value=[])), \
-         patch("autoscan.autoscan._postprocess_markdown", return_value=""), \
          patch("os.makedirs"):
         with pytest.raises(PDFPageToImageConversionError, match="Failed to convert PDF pages to images."):
             await autoscan(pdf_path, temp_dir=str(temp_dir))
@@ -84,7 +82,6 @@ async def test_autoscan_temp_dir_cleanup(tmp_path):
          patch("autoscan.autoscan._process_images_async", new=AsyncMock(return_value=(["Markdown Page 1"], 50, 50, 0.1))), \
          patch("autoscan.autoscan.write_text_to_file", new=AsyncMock(return_value="sample.pdf")) as mock_write, \
          patch("autoscan.autoscan._cleanup_temp_files") as mock_cleanup, \
-         patch("autoscan.autoscan._postprocess_markdown", return_value=""), \
          patch("os.makedirs"):
         # Run the function
         await autoscan(pdf_path, temp_dir=str(temp_dir), cleanup_temp=True)
@@ -103,7 +100,6 @@ async def test_autoscan_no_cleanup(tmp_path):
          patch("autoscan.autoscan._process_images_async", return_value=(["Markdown content"], 10, 20, 0.2)), \
          patch("autoscan.autoscan.write_text_to_file", new=AsyncMock(return_value="output.md")), \
          patch("autoscan.autoscan._cleanup_temp_files") as mock_cleanup, \
-         patch("autoscan.autoscan._postprocess_markdown", return_value=""), \
          patch("os.makedirs"):
         await autoscan(pdf_path, temp_dir=str(temp_dir), cleanup_temp=False)
         mock_cleanup.assert_not_called()
@@ -121,7 +117,6 @@ async def test_autoscan_model_failure(tmp_path):
     with patch("autoscan.autoscan.get_or_download_file", return_value=str(temp_dir / "sample.pdf")), \
          patch("autoscan.autoscan.pdf_to_images", return_value=["image1.png"]), \
          patch("autoscan.autoscan.LlmModel") as MockModel, \
-         patch("autoscan.autoscan._postprocess_markdown", return_value=""), \
          patch("os.makedirs"):
         model_instance = MockModel.return_value
         model_instance.image_to_markdown_completion = mock_completion
@@ -141,7 +136,6 @@ async def test_autoscan_markdown_write_failure(tmp_path):
          patch("autoscan.autoscan.pdf_to_images", return_value=["image1.png"]), \
          patch("autoscan.autoscan._process_images_async", return_value=(["Some content"], 10, 20, 0.2)), \
          patch("autoscan.autoscan.write_text_to_file", return_value=None), \
-         patch("autoscan.autoscan._postprocess_markdown", return_value=""), \
          patch("os.makedirs"):
         with pytest.raises(MarkdownFileWriteError):
             await autoscan(pdf_path, temp_dir=str(temp_dir))
@@ -158,7 +152,6 @@ async def test_autoscan_with_custom_concurrency(tmp_path):
          patch("autoscan.autoscan.pdf_to_images", return_value=["image1.png", "image2.png", "image3.png"]) as mock_pdf_to_images, \
          patch("autoscan.autoscan._process_images_async", return_value=(["Page1", "Page2", "Page3"], 30, 60, 0.3)) as mock_process, \
          patch("autoscan.autoscan.write_text_to_file", return_value=str(output_dir / "sample.md")), \
-         patch("autoscan.autoscan._postprocess_markdown", return_value="Page1 Page2 Page3"), \
          patch("os.makedirs"):
         # Run with concurrency=2
         result = await autoscan(pdf_path, temp_dir=str(temp_dir), output_dir=str(output_dir), concurrency=2)


### PR DESCRIPTION
## Summary
- send full previous page in high accuracy mode
- remove post-processing LLM step
- drop final review prompt
- document new high accuracy behavior

## Testing
- `python3 -m py_compile autoscan/*.py tests/*.py`
- `pytest -q` *(fails: command not found)*