### PR TITLE
Rewrite previous page in high accuracy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ After installing dependencies (e.g. `poetry install`), run `autoscan` from the c
 ```sh
 autoscan path/to/your/file.pdf
 
-# Choose accuracy level (low, medium, high):
+# Choose accuracy level (low or high):
 autoscan --accuracy high path/to/your/file.pdf
 
 # Specify a model (default is `openai/gpt-4o`):
@@ -93,7 +93,7 @@ autoscan --instructions "This is an invoice; use GitHub tables" path/to/your/fil
 
 ### Accuracy Levels
 
-`low`, `medium`, and `high` are supported. Higher accuracy processes pages sequentially. When using `high`, the entire previous page is sent back to the model for context, which increases token usage (cost) and runtime.
+Two accuracy levels are available: `low` and `high`. `low` processes pages in parallel, while `high` processes them sequentially. In `high` mode the entire previous page is returned to the model so it can rewrite that page together with the current one for consistent formatting. The model responds in JSON with `page_1` and `page_2` fields so AutoScan can replace the prior page with the updated version. This increases token usage and runtime.
 
 ### Programmatic Example
 
@@ -125,7 +125,7 @@ Configure models and other parameters using the `autoscan` function signature:
 async def autoscan(
     pdf_path: str,
     model_name: str = "openai/gpt-4o",
-    accuracy: str = "medium",
+    accuracy: str = "low",
     user_instructions: Optional[str] = None,
     temp_dir: Optional[str] = None,
     cleanup_temp: bool = True,

--- a/autoscan/cli.py
+++ b/autoscan/cli.py
@@ -24,7 +24,7 @@ async def _process_file(
 async def _run(
     pdf_path: str | None = None,
     model: str = "openai/gpt-4o",
-    accuracy: str = "medium",
+    accuracy: str = "low",
     instructions: str | None = None,
 ) -> None:
     if pdf_path:
@@ -42,8 +42,8 @@ def main() -> None:
     parser.add_argument(
         "--accuracy",
         type=str,
-        choices=["low", "medium", "high"],
-        default="medium",
+        choices=["low", "high"],
+        default="low",
         help="Conversion accuracy level",
     )
     parser.add_argument(

--- a/autoscan/prompts.py
+++ b/autoscan/prompts.py
@@ -34,3 +34,20 @@ You are given an image of a PDF page (called main image). Your task is to conver
 
 **Your response must follow these rules and contain only the converted Markdown content.**
     """
+
+HIGH_ACCURACY_PROMPT = (
+    DEFAULT_SYSTEM_PROMPT
+    + """
+
+When provided with Markdown from a previous page, rewrite that page together
+with the current page so that tone, formatting, and layout are consistent.
+Return your answer as JSON:
+
+{
+  "page_1": "<revised previous page>",
+  "page_2": "<revised current page>"
+}
+
+If no previous page is given, return plain Markdown as usual.
+"""
+)

--- a/tests/test_autoscan.py
+++ b/tests/test_autoscan.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from autoscan.autoscan import autoscan
 import autoscan.autoscan as autoscan_module
 from autoscan.errors import PDFFileNotFoundError, PDFPageToImageConversionError, MarkdownFileWriteError, LLMProcessingError
+import json
 from autoscan.types import AutoScanOutput, ModelResult
 
 
@@ -172,9 +173,11 @@ async def test_process_images_async_sequential():
 
     async def fake_image_to_markdown(image_path, previous_page_markdown=None, user_instructions=None):
         calls.append(previous_page_markdown)
-        return ModelResult(
-            content=f"md_{image_path}", prompt_tokens=1, completion_tokens=1, cost=0.0
-        )
+        if previous_page_markdown:
+            content = json.dumps({"page_1": previous_page_markdown, "page_2": f"md_{image_path}"})
+        else:
+            content = f"md_{image_path}"
+        return ModelResult(content=content, prompt_tokens=1, completion_tokens=1, cost=0.0)
 
     model = MagicMock()
     model.image_to_markdown.side_effect = fake_image_to_markdown

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from autoscan.utils.env import get_env_var_for_model
 async def test_process_file_passes_accuracy():
     called = {}
 
-    async def fake_autoscan(pdf_path, model_name="openai/gpt-4o", accuracy="medium", user_instructions=None):
+    async def fake_autoscan(pdf_path, model_name="openai/gpt-4o", accuracy="low", user_instructions=None):
         called['accuracy'] = accuracy
         called['model'] = model_name
 


### PR DESCRIPTION
## Summary
- allow `high` accuracy mode to rewrite prior page for consistency
- keep only final merged markdown when running sequentially
- update documentation to describe high accuracy behaviour
- adjust sequential tests for new output

## Testing
- `pytest -q` *(fails: Command not found: pytest)*